### PR TITLE
Update Beta List Params

### DIFF
--- a/panoptes.rb
+++ b/panoptes.rb
@@ -121,7 +121,7 @@ class PanoptesClient
     return @split_beta_lists if @split_beta_lists
 
     @split_beta_lists = {}
-    shuffled_beta_list.each_slice(50000).with_index do |a, i|
+    shuffled_beta_list.each_slice(75000).with_index do |a, i|
       @split_beta_lists["beta_list_#{i}"] = a
     end
     @split_beta_lists

--- a/panoptes.rb
+++ b/panoptes.rb
@@ -103,7 +103,7 @@ class PanoptesClient
   end
 
   def beta_lists
-    @beta_lists ||= %w[beta_list_1 beta_list_2 beta_list_3].map do |list_name|
+    @beta_lists ||= %w[beta_list_1 beta_list_2 beta_list_3 beta_list_4].map do |list_name|
       {
         'uuid' => SecureRandom.uuid,
         'name' => list_name,

--- a/sync.rb
+++ b/sync.rb
@@ -39,11 +39,12 @@ listmonk.lists_by_id
 puts 'Subscribing general lists...'
 listmonk.subscribe_users(panoptes.list_emailable_users.except('beta_email_communication'))
 
-# Subscribe only 3 beta sublists
+# Subscribe 4 beta sublists
 puts 'Subscribing beta lists...'
 listmonk.subscribe_users({ 'beta_list_1' => panoptes.split_beta_lists['beta_list_1'] })
 listmonk.subscribe_users({ 'beta_list_2' => panoptes.split_beta_lists['beta_list_2'] })
 listmonk.subscribe_users({ 'beta_list_3' => panoptes.split_beta_lists['beta_list_3'] })
+listmonk.subscribe_users({ 'beta_list_4' => panoptes.split_beta_lists['beta_list_4'] })
 
 puts 'Subscribing project lists...'
 grouped_by_project = panoptes.project_emailable_users.group_by { |h| h['slug'] }


### PR DESCRIPTION
Closes #1. PR increases the size of each beta list from 50k to 75k and adds a fourth beta list (typical only use max = 3, but good to have additional list for backup). 4 lists x 75k = 300k beta volunteers required (currently: 316k as of 7 Dec 2023).