### PR TITLE
Refine table truncation to account for new persistent subscriber and list IDs

### DIFF
--- a/listmonk.rb
+++ b/listmonk.rb
@@ -6,15 +6,15 @@ class ListmonkClient
   end
 
   def truncate_subscribers_table
-    monkconn.exec('TRUNCATE TABLE subscribers CASCADE')
+    monkconn.exec('TRUNCATE TABLE subscribers')
   end
 
   def truncate_lists_table
-    monkconn.exec('TRUNCATE TABLE lists CASCADE')
+    monkconn.exec('TRUNCATE TABLE lists')
   end
 
   def truncate_subscriber_lists_table
-    monkconn.exec('TRUNCATE TABLE subscriber_lists CASCADE')
+    monkconn.exec('TRUNCATE TABLE subscriber_lists')
   end
 
   def import_subscribers(subscriber_list)


### PR DESCRIPTION
This PR continues work toward and closes #3, building on the creation of persistent IDs for subscribers and lists in #4. 

Here, I remove the `CASCADE` option from `TRUNCATE` table commands, allowing four tables to persist across the sync that were previously cleaned up (due to foreign IDs from subscribers and lists tables):
1. `campaign_lists`
1. `campaign_views`
1. `link_clicks`
1. `bounces`

The three explicit (non-`CASCADE`) `TRUNCATE` commands (`listmonk.truncate_subscribers_table`, `listmonk.truncate_lists_table`, `listmonk.truncate_subscriber_lists_table`; executed [here](https://github.com/zooniverse/listmonk-sync/blob/main/sync.rb#L22-L24)) will continue to clear the three tables we wish to refresh in full during each sync:
1. `subscribers`
1. `lists`
1. `subscriber_lists`
