### PR TITLE
Revert "Refine table truncation to account for new persistent subscriber and list IDs"

### DIFF
--- a/listmonk.rb
+++ b/listmonk.rb
@@ -6,15 +6,15 @@ class ListmonkClient
   end
 
   def truncate_subscribers_table
-    monkconn.exec('TRUNCATE TABLE subscribers')
+    monkconn.exec('TRUNCATE TABLE subscribers CASCADE')
   end
 
   def truncate_lists_table
-    monkconn.exec('TRUNCATE TABLE lists')
+    monkconn.exec('TRUNCATE TABLE lists CASCADE')
   end
 
   def truncate_subscriber_lists_table
-    monkconn.exec('TRUNCATE TABLE subscriber_lists')
+    monkconn.exec('TRUNCATE TABLE subscriber_lists CASCADE')
   end
 
   def import_subscribers(subscriber_list)


### PR DESCRIPTION
Reverts zooniverse/listmonk-sync#5

Postgres does not allow tables to be truncated that have foreign key references in other tables. While that would have been convenient for our purposes, in the case where we can manually confirm that old foreign IDs will match new foreign IDs, looks like we'll have to do without.