### PR TITLE
Sync should not delete roles and users

### DIFF
--- a/listmonk.rb
+++ b/listmonk.rb
@@ -10,7 +10,11 @@ class ListmonkClient
   end
 
   def truncate_lists_table
-    monkconn.exec('TRUNCATE TABLE lists CASCADE')
+    monkconn.exec('TRUNCATE TABLE lists')
+  end
+
+  def truncate_campaign_lists_table
+    monkconn.exec('TRUNCATE TABLE campaign_lists')
   end
 
   def truncate_subscriber_lists_table

--- a/sync.rb
+++ b/sync.rb
@@ -21,6 +21,7 @@ subscribers = panoptes.subscribers
 puts 'Truncating Listmonk tables...'
 listmonk.truncate_subscribers_table
 listmonk.truncate_lists_table
+listmonk.truncate_campaign_lists_table
 listmonk.truncate_subscriber_lists_table
 
 puts 'Importing subscribers...'


### PR DESCRIPTION
The new Listmonk v4 includes new roles and users tables for internal authentication. The roles table has a nullable foreign key to the lists table, and due to the use of `CASCADE;`, caused the roles and subsequently users tables to also be truncated.

This removes the `CASCADE;` from the list truncate and adds an additional truncate query for campaign_lists which was previously implicit via the cascade.