### PR TITLE
Fix TRUNCATE...CASCADE issue with lists and roles tables

### DIFF
--- a/listmonk.rb
+++ b/listmonk.rb
@@ -6,19 +6,16 @@ class ListmonkClient
   end
 
   def truncate_subscribers_table
-    monkconn.exec('TRUNCATE TABLE subscribers CASCADE')
-  end
-
-  def truncate_lists_table
-    monkconn.exec('TRUNCATE TABLE lists')
+    monkconn.exec('TRUNCATE TABLE subscribers RESTART IDENTITY CASCADE')
   end
 
   def truncate_campaign_lists_table
-    monkconn.exec('TRUNCATE TABLE campaign_lists')
+    monkconn.exec('TRUNCATE TABLE campaign_lists RESTART IDENTITY CASCADE')
   end
 
-  def truncate_subscriber_lists_table
-    monkconn.exec('TRUNCATE TABLE subscriber_lists CASCADE')
+  def truncate_lists_table
+    monkconn.exec('DELETE FROM lists')
+    monkconn.exec('ALTER SEQUENCE lists_id_seq RESTART WITH 1')
   end
 
   def import_subscribers(subscriber_list)

--- a/listmonk.rb
+++ b/listmonk.rb
@@ -13,7 +13,7 @@ class ListmonkClient
     monkconn.exec('TRUNCATE TABLE campaign_lists RESTART IDENTITY CASCADE')
   end
 
-  def truncate_lists_table
+  def delete_from_lists_table
     monkconn.exec('DELETE FROM lists')
     monkconn.exec('ALTER SEQUENCE lists_id_seq RESTART WITH 1')
   end

--- a/sync.rb
+++ b/sync.rb
@@ -21,7 +21,7 @@ subscribers = panoptes.subscribers
 puts 'Truncating Listmonk tables...'
 listmonk.truncate_subscribers_table
 listmonk.truncate_campaign_lists_table
-listmonk.truncate_lists_table
+listmonk.delete_from_lists_table
 
 puts 'Importing subscribers...'
 listmonk.import_subscribers(subscribers)

--- a/sync.rb
+++ b/sync.rb
@@ -20,9 +20,8 @@ subscribers = panoptes.subscribers
 
 puts 'Truncating Listmonk tables...'
 listmonk.truncate_subscribers_table
-listmonk.truncate_lists_table
 listmonk.truncate_campaign_lists_table
-listmonk.truncate_subscriber_lists_table
+listmonk.truncate_lists_table
 
 puts 'Importing subscribers...'
 listmonk.import_subscribers(subscribers)


### PR DESCRIPTION
Truncating the lists table using the CASCADE option truncates the new roles table due to the foreign key in the latter for list-based permissions. This breaks login, and removing the CASCADE throws an error. So, truncate & cascade the tables that can, but just `DELETE FROM lists` to avoid this conflict. This is never a large table (~500 rows) so this operation isn't meaningfully slower (not that it would matter if it was since this is an scheduled job).

subscriber_lists cascade-truncates from subscribers, so that step could be removed.

Also, all these truncates and deletes now reset the associated sequences so that the ids don't just increase into infinity.