### PR TITLE
Update Ruby base image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ build-iPhoneSimulator/
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
+.ruby-version
 
 # Used by RuboCop. Remote config files pulled in from inherit_from directive.
 # .rubocop-https?--*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.2-buster
+FROM ruby:3.3
 WORKDIR /app
 
 RUN apt-get update && \

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ GEM
     pg (1.4.6)
 
 PLATFORMS
+  arm64-darwin-24
   x86_64-darwin-19
   x86_64-darwin-22
 
@@ -11,4 +12,4 @@ DEPENDENCIES
   pg
 
 BUNDLED WITH
-   2.4.12
+   2.3.26


### PR DESCRIPTION
Update to Ruby 3.3 and slice the `-buster` off the base image.