### PR TITLE
Add beta approved project lists to listmonk

### DIFF
--- a/panoptes.rb
+++ b/panoptes.rb
@@ -72,9 +72,9 @@ class PanoptesClient
         AND (
           projects.launch_approved = TRUE
           OR (
-              NOT projects.launch_approved
-			        AND projects.beta_approved
-			        AND projects.created_at > NOW()::date - INTERVAL '2 years'
+              projects.launch_approved = FALSE
+			  AND projects.beta_approved = TRUE
+			  AND projects.created_at > NOW()::date - INTERVAL '2 years'
           )
         )"
     ).entries

--- a/panoptes.rb
+++ b/panoptes.rb
@@ -69,7 +69,14 @@ class PanoptesClient
       	user_project_preferences.email_communication = TRUE
       	AND users.activated_state = 0
       	AND users.valid_email = TRUE
-        AND projects.launch_approved = TRUE"
+        AND (
+          projects.launch_approved = TRUE
+          OR (
+              NOT projects.launch_approved
+			        AND projects.beta_approved
+			        AND projects.created_at > NOW()::date - INTERVAL '2 years'
+          )
+        )"
     ).entries
   end
 


### PR DESCRIPTION
The occasional need has arisen where it would be useful to email projects that are not yet launch approved, but have gone through a (first) beta test -- e.g., to recruit volunteers to return for a second beta test. Currently, sending emails to project participants of non-launch approved projects requires the team to manually create a custom list. Adding recent beta approved projects (within the last two years, but not yet launch approved) to the project lists we make available on listmonk is a reasonable increase in scope (currently, an increase of 13 projects -- from 534 to 547) with good return on investment.